### PR TITLE
Fixed error when contain unrecognized mime file.

### DIFF
--- a/src/WebrootPreloadMiddleware.php
+++ b/src/WebrootPreloadMiddleware.php
@@ -50,6 +50,9 @@ final class WebrootPreloadMiddleware
             ];
 
             $mime = MimeTypeByExtensionGuesser::guess($fileinfo->getExtension());
+            if (is_null($mime)) {
+                $mime = 'application/octet-stream';
+            }
             list($mime) = explode(';', $mime);
             if (strpos($mime, '/') !== false) {
                 $this->files[$filePath]['mime'] = $mime;

--- a/tests/WebrootPreloadMiddlewareTest.php
+++ b/tests/WebrootPreloadMiddlewareTest.php
@@ -71,8 +71,12 @@ final class WebrootPreloadMiddlewareTest extends TestCase
                 'message' => '/robots.txt: 68B',
             ],
             [
+                'level' => 'debug',
+                'message' => '/unknown.unknown_extension: 73B',
+            ],
+            [
                 'level' => 'info',
-                'message' => 'Preloaded 9 file(s) with a combined size of 6.68MiB from "' . $webroot . '" into memory',
+                'message' => 'Preloaded 10 file(s) with a combined size of 6.68MiB from "' . $webroot . '" into memory',
             ],
         ], $logger->getMessages());
     }

--- a/tests/webroot/unknown.unknown_extension
+++ b/tests/webroot/unknown.unknown_extension
@@ -1,0 +1,1 @@
+note: MimeTypeByExtensionGuesser won't be able to guess this file's mime.


### PR DESCRIPTION
I found a tiny problem.
webroot preload middleware will fail when couldn't get MIME type.

rel: https://twitter.com/uzulla/status/972119003144454144

thanks.