### PR TITLE
enable leverage of 'If-Match' Headers

### DIFF
--- a/src/WebrootPreloadMiddleware.php
+++ b/src/WebrootPreloadMiddleware.php
@@ -93,6 +93,14 @@ final class WebrootPreloadMiddleware
                 }
             }
 
+            if ($request->hasHeader('If-Match')) {
+                $expectedEtag = current($request->getHeader('If-Match'));
+                $expectedEtag = trim($expectedEtag, '"');
+                if ($expectedEtag !== $item['etag']) {
+                    return new Response(412);
+                }
+            }
+
             $response = (new Response(200))->
                 withBody(stream_for($item['contents']))->
                 withHeader('ETag', '"' . $item['etag'] . '"')


### PR DESCRIPTION
Basic implementation of 'If-Match' Header support.
as of:
https://github.com/WyriHaximus/reactphp-http-middleware-webroot-preload/issues/10